### PR TITLE
Support for Perl-like regular expressions with git-grep

### DIFF
--- a/git-secrets
+++ b/git-secrets
@@ -102,7 +102,7 @@ scan_history() {
   # Looks for differences matching the patterns, reduces the number of revisions to scan
   local to_scan=$(git log --all -G"${combined_patterns}" --pretty=%H)
   # Scan through revisions with findings to normalize output
-  output=$(GREP_OPTIONS= LC_ALL=C git grep -nwHEI "${combined_patterns}" $to_scan)
+  output=$(GREP_OPTIONS= LC_ALL=C git grep -nwHEIP "${combined_patterns}" $to_scan)
   process_output $? "${output}"
 }
 
@@ -113,7 +113,7 @@ git_grep() {
   local files=("${@}") combined_patterns=$(load_combined_patterns)
 
   [ -z "${combined_patterns}" ] && return 1
-  GREP_OPTIONS= LC_ALL=C git grep -nwHEI ${options} "${combined_patterns}" -- "${files[@]}"
+  GREP_OPTIONS= LC_ALL=C git grep -nwHEIP ${options} "${combined_patterns}" -- "${files[@]}"
 }
 
 # Performs a regular grep, taking into account patterns and recursion.


### PR DESCRIPTION
*What?*
Enable perl-like regular expressions for git-grep.

*Why?*
It's a requirement for us. The systems we intend to run on will support this flag.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
