### PR TITLE
Add --scan-between functionality.

### DIFF
--- a/.github/workflows/run-bats.yaml
+++ b/.github/workflows/run-bats.yaml
@@ -1,0 +1,11 @@
+name: Run bats tests
+on: [pull_request]
+jobs:
+  test:
+    name: Run tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Run Bats tests
+        run: make test

--- a/README.rst
+++ b/README.rst
@@ -146,7 +146,7 @@ Each of these options must appear first on the command line.
     a colon, and then the line of text that matched.
 
 ``--scan-between``
-    Scans the repository between two given commit hashes using [ancestory path](https://git-scm.com/docs/git-log#Documentation/git-log.txt---ancestry-path).
+    Scans the repository between two given commit hashes using `ancestory path <https://git-scm.com/docs/git-log#Documentation/git-log.txt---ancestry-path`_.
     For example `hashA..hashB`. The scan begins AFTER the first hash. So, to
     include `hashA`, you must specify `hashA~1..hashB` as the argument.
     Similarly, for to scan the last commit, use: `HEAD~1..HEAD`.

--- a/README.rst
+++ b/README.rst
@@ -15,6 +15,7 @@ Synopsis
 
     git secrets --scan [-r|--recursive] [--cached] [--no-index] [--untracked] [<files>...]
     git secrets --scan-history
+    git secrets --scan-between hashA..hashB
     git secrets --install [-f|--force] [<target-directory>]
     git secrets --list [--global]
     git secrets --add [-a|--allowed] [-l|--literal] [--global] <pattern>
@@ -143,6 +144,12 @@ Each of these options must appear first on the command line.
     script will exit with a non-zero status. Each matched line will be written with
     the name of the file that matched, a colon, the line number that matched,
     a colon, and then the line of text that matched.
+
+``--scan-between``
+    Scans the repository between two given commit hashes. For example `hashA..hashB`.
+    The scan begins AFTER the first hash. So, to include `hashA`, you must specify
+    `hashA~1..hashB` as the argument. Similarly, for to scan the last commit, use:
+    `HEAD~1..HEAD`.
 
 ``--list``
     Lists the ``git-secrets`` configuration for the current repo or in the global

--- a/README.rst
+++ b/README.rst
@@ -146,10 +146,10 @@ Each of these options must appear first on the command line.
     a colon, and then the line of text that matched.
 
 ``--scan-between``
-    Scans the repository between two given commit hashes. For example `hashA..hashB`.
-    The scan begins AFTER the first hash. So, to include `hashA`, you must specify
-    `hashA~1..hashB` as the argument. Similarly, for to scan the last commit, use:
-    `HEAD~1..HEAD`.
+    Scans the repository between two given commit hashes using [ancestory path](https://git-scm.com/docs/git-log#Documentation/git-log.txt---ancestry-path).
+    For example `hashA..hashB`. The scan begins AFTER the first hash. So, to
+    include `hashA`, you must specify `hashA~1..hashB` as the argument.
+    Similarly, for to scan the last commit, use: `HEAD~1..HEAD`.
 
 ``--list``
     Lists the ``git-secrets`` configuration for the current repo or in the global

--- a/README.rst
+++ b/README.rst
@@ -146,7 +146,7 @@ Each of these options must appear first on the command line.
     a colon, and then the line of text that matched.
 
 ``--scan-between``
-    Scans the repository between two given commit hashes using `ancestory path <https://git-scm.com/docs/git-log#Documentation/git-log.txt---ancestry-path`_.
+    Scans the repository between two given commit hashes using `ancestory path <https://git-scm.com/docs/git-log#Documentation/git-log.txt---ancestry-path>`_.
     For example `hashA..hashB`. The scan begins AFTER the first hash. So, to
     include `hashA`, you must specify `hashA~1..hashB` as the argument.
     Similarly, for to scan the last commit, use: `HEAD~1..HEAD`.

--- a/README.rst
+++ b/README.rst
@@ -149,7 +149,7 @@ Each of these options must appear first on the command line.
     Scans the repository between two given commit hashes using `ancestory path <https://git-scm.com/docs/git-log#Documentation/git-log.txt---ancestry-path>`_.
     For example `hashA..hashB`. The scan begins AFTER the first hash. So, to
     include ``hashA``, you must specify ``hashA~1..hashB`` as the argument.
-    Similarly, for to scan the last commit, use: ``HEAD~1..HEAD``.
+    Similarly, to scan the last commit use: ``HEAD~1..HEAD``.
 
 ``--list``
     Lists the ``git-secrets`` configuration for the current repo or in the global

--- a/README.rst
+++ b/README.rst
@@ -148,8 +148,8 @@ Each of these options must appear first on the command line.
 ``--scan-between``
     Scans the repository between two given commit hashes using `ancestory path <https://git-scm.com/docs/git-log#Documentation/git-log.txt---ancestry-path>`_.
     For example `hashA..hashB`. The scan begins AFTER the first hash. So, to
-    include `hashA`, you must specify `hashA~1..hashB` as the argument.
-    Similarly, for to scan the last commit, use: `HEAD~1..HEAD`.
+    include ``hashA``, you must specify ``hashA~1..hashB`` as the argument.
+    Similarly, for to scan the last commit, use: ``HEAD~1..HEAD``.
 
 ``--list``
     Lists the ``git-secrets`` configuration for the current repo or in the global

--- a/git-secrets
+++ b/git-secrets
@@ -12,9 +12,12 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+# shellcheck disable=SC2155
+
 NONGIT_OK=1 OPTIONS_SPEC="\
 git secrets --scan [-r|--recursive] [--cached] [--no-index] [--untracked] [<files>...]
 git secrets --scan-history
+git secrets --scan-between [hashA..hashB]
 git secrets --install [-f|--force] [<target-directory>]
 git secrets --list [--global]
 git secrets --add [-a|--allowed] [-l|--literal] [--global] <pattern>
@@ -24,6 +27,7 @@ git secrets --aws-provider [<credentials-file>]
 --
 scan Scans <files> for prohibited patterns
 scan-history Scans repo for prohibited patterns
+scan-between Scans the repo for prohibited patterns between two given commit hashes
 install Installs git hooks for Git repository or Git template directory
 list Lists secret patterns
 add Adds a prohibited or allowed pattern, ensuring to de-dupe with existing patterns
@@ -104,6 +108,48 @@ scan_history() {
   # Scan through revisions with findings to normalize output
   output=$(GREP_OPTIONS= LC_ALL=C git grep -nwHEIP "${combined_patterns}" $to_scan)
   process_output $? "${output}"
+}
+
+# Takes an argument like commitHashA..commitHashB
+# Scans modified files in each commit at each point in history
+scan_between() {
+  # Fail if unstaged changes exist
+  git update-index --refresh
+  [[ -n $(git status --porcelain=v1 2>/dev/null) ]] &&
+    echo "Commit or stash changes first." && exit 1
+
+  # Require scan range (HEAD/head or SHA1 hash)
+  # Abbreviated hashes minimum 7 chars allowed
+  local -r scan_range="${1}"
+  head_or_sha1="(HEAD|head|[0-9a-f]{7,40})(\^[0-9]{1})?"
+  [[ ! ${scan_range} =~ ^${head_or_sha1}[\.]{2,3}${head_or_sha1}$ ]] &&
+    printf "Must specify a valid scan range, i.e. 'gitHashA..gitHashB'" >&2 && exit 1
+
+  # No patterns means nothing to scan for (OK)
+  local combined_patterns=$(load_combined_patterns)
+  [ -z "${combined_patterns}" ] && return 0
+
+  # No commits means nothing to scan (OK)
+  local -r commits_cmd="git log ${scan_range} --format=format:%h --reverse"
+  IFS=$'\n' read -r -d '' -a commits < <( ${commits_cmd} && printf '\0' )
+  [ -z "${commits}" ] && return 0
+  unset IFS
+
+  local -r current_branch=$(git branch --show-current)
+
+  declare found
+  for commit_hash in "${commits[@]}"; do
+    git checkout "${commit_hash}" >& /dev/null
+    local prev_commit_hash=$(git rev-parse "${commit_hash}^1")
+    local files_changed=$(git diff "${prev_commit_hash}..${commit_hash}" --name-only)
+    local buff=$(GREP_OPTIONS= LC_ALL=C git grep -nwHEIP \ "${combined_patterns}" -- ${files_changed} | sed "s/^/${commit_hash}:/")
+    [[ -n ${buff} ]] && found+=$(echo -e "\r\n${buff}")
+    unset buff
+  done
+
+  git switch "${current_branch}" >& /dev/null
+  [[ -n ${found} ]] && status=0 || status=1
+  process_output "${status}" "${found}"
 }
 
 # Performs a git-grep, taking into account patterns and options.
@@ -336,6 +382,7 @@ case "${COMMAND}" in
     ;;
   --scan) scan_with_fn_or_die "scan" "$@" ;;
   --scan-history) scan_with_fn_or_die "scan_history" "$@" ;;
+  --scan-between) scan_with_fn_or_die "scan_between" "$@" ;;
   --list)
     if [ ${GLOBAL} -eq 1 ]; then
       git config --global --get-regex secrets.*

--- a/git-secrets
+++ b/git-secrets
@@ -131,17 +131,21 @@ scan_between() {
   [[ ! ${scan_range} =~ ^${head_or_sha1}[\.]{2,3}${head_or_sha1}$ ]] &&
     printf "Must specify a valid scan range, i.e. 'gitHashA..gitHashB'" >&2 && exit 1
 
-  local scan_to=$(echo "${scan_range}" | sed -nE "s/^(.*)\.\.(.*)$/\2/p")
-  is_first_commit=$(check_if_first_commit "${scan_to}")
-  [[ ${is_first_commit} == true ]] &&
-    scan_range="4b825dc642cb6eb9a060e54bf8d69288fbee4904..HEAD"
-
   # No patterns means nothing to scan for (OK)
   local combined_patterns=$(load_combined_patterns)
   [ -z "${combined_patterns}" ] && return 0
 
+  local scan_to=$(echo "${scan_range}" | sed -nE "s/^(.*)\.\.(.*)$/\2/p")
+  is_first_commit=$(check_if_first_commit "${scan_to}")
+  if [[ ${is_first_commit} == true ]]; then
+    scan_range="4b825dc642cb6eb9a060e54bf8d69288fbee4904..HEAD"
+    # First commit is bottom commit
+    local -r commits_cmd="git log ${scan_range} --pretty=%h --reverse"
+  else
+    local -r commits_cmd="git log ${scan_range} --pretty=%h --reverse --ancestry-path"
+  fi
+
   # No commits means nothing to scan (OK)
-  local -r commits_cmd="git log ${scan_range} --pretty=%h --reverse"
   IFS=$'\n' read -r -d '' -a commits < <( ${commits_cmd} && printf '\0' )
   [ -z "${commits}" ] && return 0
   unset IFS

--- a/git-secrets
+++ b/git-secrets
@@ -110,27 +110,33 @@ scan_history() {
   process_output $? "${output}"
 }
 
+check_if_first_commit() {
+  local -r first_commit=$(git rev-list --max-parents=0 HEAD)
+  local scan_to=${1}
+  [[ ${scan_to} == "HEAD" ]] && scan_to=$(git rev-parse HEAD)
+  if [[ ${scan_to} == ${first_commit} ]]; then
+    # null-tree-SHA1..HEAD
+    scan_range="4b825dc642cb6eb9a060e54bf8d69288fbee4904..HEAD"
+    echo true
+  else
+    echo false
+  fi
+}
+
 # Takes an argument like commitHashA..commitHashB
 # Scans modified files in each commit at each point in history
 scan_between() {
   # Require scan range (HEAD/head or SHA1 hash)
   # Abbreviated hashes minimum 7 chars allowed
   local scan_range="${1}"
-  local -r head_or_sha1="(HEAD|head|[0-9a-f]{7,40})(\^[0-9]{1})?"
+  local -r head_or_sha1="(HEAD|head|[0-9a-f]{7,40})(\~[0-9]{1})?"
   [[ ! ${scan_range} =~ ^${head_or_sha1}[\.]{2,3}${head_or_sha1}$ ]] &&
     printf "Must specify a valid scan range, i.e. 'gitHashA..gitHashB'" >&2 && exit 1
 
-  # In case this is the first commit of the repo
-  local -r first_commit=$(git rev-list --max-parents=0 HEAD)
   local scan_to=$(echo "${scan_range}" | sed -nE "s/^(.*)\.\.(.*)$/\2/p")
-  [[ ${scan_to} == "HEAD" ]] && scan_to=$(git rev-parse HEAD)
-  if [[ ${scan_to} == ${first_commit} ]]; then
-    # null-tree-SHA1..HEAD
+  is_first_commit=$(check_if_first_commit "${scan_to}")
+  [[ ${is_first_commit} == true ]] &&
     scan_range="4b825dc642cb6eb9a060e54bf8d69288fbee4904..HEAD"
-    local -r is_first_commit=true
-  else
-    local -r is_first_commit=false
-  fi
 
   # No patterns means nothing to scan for (OK)
   local combined_patterns=$(load_combined_patterns)

--- a/git-secrets
+++ b/git-secrets
@@ -115,8 +115,6 @@ check_if_first_commit() {
   local scan_to=${1}
   [[ ${scan_to} == "HEAD" ]] && scan_to=$(git rev-parse HEAD)
   if [[ ${scan_to} == ${first_commit} ]]; then
-    # null-tree-SHA1..HEAD
-    scan_range="4b825dc642cb6eb9a060e54bf8d69288fbee4904..HEAD"
     echo true
   else
     echo false

--- a/git-secrets
+++ b/git-secrets
@@ -115,8 +115,8 @@ scan_history() {
 scan_between() {
   # Fail if unstaged changes exist
   git update-index --refresh
-  [[ -n $(git status --porcelain=v1 2>/dev/null) ]] &&
-    echo "Commit or stash changes first." && exit 1
+  [[ -n $(git status --porcelain=v1 2> /dev/null) ]] &&
+    printf "Commit or stash changes first." >&2 && exit 1
 
   # Require scan range (HEAD/head or SHA1 hash)
   # Abbreviated hashes minimum 7 chars allowed

--- a/git-secrets
+++ b/git-secrets
@@ -113,24 +113,31 @@ scan_history() {
 # Takes an argument like commitHashA..commitHashB
 # Scans modified files in each commit at each point in history
 scan_between() {
-  # Fail if unstaged changes exist
-  git update-index --refresh
-  [[ -n $(git status --porcelain=v1 2> /dev/null) ]] &&
-    printf "Commit or stash changes first." >&2 && exit 1
-
   # Require scan range (HEAD/head or SHA1 hash)
   # Abbreviated hashes minimum 7 chars allowed
-  local -r scan_range="${1}"
-  head_or_sha1="(HEAD|head|[0-9a-f]{7,40})(\^[0-9]{1})?"
+  local scan_range="${1}"
+  local -r head_or_sha1="(HEAD|head|[0-9a-f]{7,40})(\^[0-9]{1})?"
   [[ ! ${scan_range} =~ ^${head_or_sha1}[\.]{2,3}${head_or_sha1}$ ]] &&
     printf "Must specify a valid scan range, i.e. 'gitHashA..gitHashB'" >&2 && exit 1
+
+  # In case this is the first commit of the repo
+  local -r first_commit=$(git rev-list --max-parents=0 HEAD)
+  local scan_to=$(echo "${scan_range}" | sed -nE "s/^(.*)\.\.(.*)$/\2/p")
+  [[ ${scan_to} == "HEAD" ]] && scan_to=$(git rev-parse HEAD)
+  if [[ ${scan_to} == ${first_commit} ]]; then
+    # null-tree-SHA1..HEAD
+    scan_range="4b825dc642cb6eb9a060e54bf8d69288fbee4904..HEAD"
+    local -r is_first_commit=true
+  else
+    local -r is_first_commit=false
+  fi
 
   # No patterns means nothing to scan for (OK)
   local combined_patterns=$(load_combined_patterns)
   [ -z "${combined_patterns}" ] && return 0
 
   # No commits means nothing to scan (OK)
-  local -r commits_cmd="git log ${scan_range} --format=format:%h --reverse"
+  local -r commits_cmd="git log ${scan_range} --pretty=%h --reverse"
   IFS=$'\n' read -r -d '' -a commits < <( ${commits_cmd} && printf '\0' )
   [ -z "${commits}" ] && return 0
   unset IFS
@@ -139,15 +146,17 @@ scan_between() {
 
   declare found
   for commit_hash in "${commits[@]}"; do
-    git checkout "${commit_hash}" >& /dev/null
-    local prev_commit_hash=$(git rev-parse "${commit_hash}^1")
-    local files_changed=$(git diff "${prev_commit_hash}..${commit_hash}" --name-only)
-    local buff=$(GREP_OPTIONS= LC_ALL=C git grep -nwHEIP \ "${combined_patterns}" -- ${files_changed} | sed "s/^/${commit_hash}:/")
+    if [[ ${is_first_commit} == true ]]; then
+      local files_changed=$(git diff HEAD --name-only)
+    else
+      local prev_commit_hash=$(git rev-parse "${commit_hash}^1")
+      local files_changed=$(git diff "${prev_commit_hash}..${commit_hash}" --name-only)
+    fi
+    local buff=$(GREP_OPTIONS= LC_ALL=C git grep -nwHEIP "${combined_patterns}" "${commit_hash}" -- ${files_changed})
     [[ -n ${buff} ]] && found+=$(echo -e "\r\n${buff}")
     unset buff
   done
 
-  git switch "${current_branch}" >& /dev/null
   [[ -n ${found} ]] && status=0 || status=1
   process_output "${status}" "${found}"
 }

--- a/test/git-secrets.bats
+++ b/test/git-secrets.bats
@@ -1,12 +1,6 @@
 #!/usr/bin/env bats
 load test_helper
 
-@test "--scan-between fails commit at HEAD^1 with secrets" {
-  setup_bad_repo_history
-  repo_run git-secrets --scan-between HEAD^1..HEAD
-  [ $status -eq 1 ]
-}
-
 @test "no arguments prints usage instructions" {
   repo_run git-secrets
   [ $status -eq 0 ]
@@ -78,9 +72,15 @@ load test_helper
   [ $status -eq 1 ]
 }
 
+@test "--scan-between fails commit at HEAD~1 with secrets" {
+  setup_bad_repo_history
+  repo_run git-secrets --scan-between HEAD~1..HEAD
+  [ $status -eq 1 ]
+}
+
 @test "--scan-between passes at HEAD without secrets" {
   setup_good_repo_history
-  repo_run git-secrets --scan-between HEAD^1..HEAD
+  repo_run git-secrets --scan-between HEAD~1..HEAD
   [ $status -eq 0 ]
 }
 
@@ -94,7 +94,7 @@ load test_helper
   git add -A
   git commit -m "Good commit"
   cd -
-  repo_run git-secrets --scan-between "HEAD^1..HEAD"
+  repo_run git-secrets --scan-between "HEAD~1..HEAD"
   [ $status -eq 0 ]
   repo_run git-secrets --scan-between "${from}..HEAD"
   [ $status -eq 1 ]

--- a/test/git-secrets.bats
+++ b/test/git-secrets.bats
@@ -1,39 +1,6 @@
 #!/usr/bin/env bats
 load test_helper
 
-@test "Scans commit at HEAD with secrets" {
-  setup_bad_repo_history
-  repo_run git-secrets --scan-between HEAD..HEAD
-  [ $status -eq 1 ]
-}
-
-@test "Scans commit at HEAD without secrets" {
-  setup_good_repo_history
-  repo_run git-secrets --scan-between HEAD..HEAD
-  [ $status -eq 0 ]
-}
-
-@test "Scans commit at HEAD^1 with secrets" {
-  cd $TEST_REPO
-  echo '@todo' > $TEST_REPO/history_failure.txt
-  git add -A
-  git commit -m "Bad commit"
-  from_commit=$(git rev-parse HEAD)
-  echo 'hi' > $TEST_REPO/harmless.txt
-  git add -A
-  git commit -m "Good commit"
-  cd -
-  repo_run git-secrets --scan-between "HEAD..HEAD"
-  [ $status -eq 0 ]
-  repo_run git-secrets --scan-between "${from}..HEAD"
-  [ $status -eq 1 ]
-}
-
-@test "--scan-between fails with invalid SHA1 hash" {
-  repo_run git-secrets --scan-between "abc..def"
-  [ $status -eq 1 ]
-}
-
 @test "no arguments prints usage instructions" {
   repo_run git-secrets
   [ $status -eq 0 ]
@@ -103,6 +70,57 @@ load test_helper
   cd -
   repo_run git-secrets --scan-history
   [ $status -eq 1 ]
+}
+
+@test "--scan-between fails commit at HEAD with secrets" {
+  setup_bad_repo_history
+  repo_run git-secrets --scan-between HEAD..HEAD
+  [ $status -eq 1 ]
+}
+
+@test "--scan-between passes at HEAD without secrets" {
+  setup_good_repo_history
+  repo_run git-secrets --scan-between HEAD..HEAD
+  [ $status -eq 0 ]
+}
+
+@test "--scan-between fails at commit at HEAD^1 with secrets" {
+  cd $TEST_REPO
+  echo '@todo' > $TEST_REPO/history_failure.txt
+  git add -A
+  git commit -m "Bad commit"
+  from_commit=$(git rev-parse HEAD)
+  echo 'hi' > $TEST_REPO/harmless.txt
+  git add -A
+  git commit -m "Good commit"
+  cd -
+  repo_run git-secrets --scan-between "HEAD..HEAD"
+  [ $status -eq 0 ]
+  repo_run git-secrets --scan-between "${from}..HEAD"
+  [ $status -eq 1 ]
+}
+
+@test "--scan-between fails with invalid SHA1 hash" {
+  repo_run git-secrets --scan-between "abc..def"
+  [ $status -eq 1 ]
+}
+
+@test "--scan-between fails with unstaged changes" {
+  cd $TEST_REPO
+  echo 'hi' > $TEST_REPO/harmless.txt
+  cd -
+  repo_run git-secrets --scan-between "HEAD..HEAD"
+  [ $status -eq 1 ]
+  [ "${lines[0]}" == "Commit or stash changes first." ]
+}
+
+@test "--scan-between fails with staged changes" {
+  cd $TEST_REPO
+  echo 'hi' > $TEST_REPO/harmless.txt
+  cd -
+  repo_run git-secrets --scan-between "HEAD..HEAD"
+  [ $status -eq 1 ]
+  [ "${lines[0]}" == "Commit or stash changes first." ]
 }
 
 @test "Scans recursively" {

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -92,3 +92,12 @@ setup_good_repo() {
   git add -A
   cd -
 }
+
+# Creates a repo with a commit that does not fail
+setup_good_repo_history() {
+  cd $TEST_REPO
+  echo 'hello!' > $TEST_REPO/data.txt
+  git add -A
+  git commit -m "Testing history"
+  cd -
+}


### PR DESCRIPTION
## What?
- Adds functionality for `--scan-between hashA..hashB`.
- Add actions runner for tests

## Why?
This is so we can scan the state of all files that have changed for every commit of a given branch.
Any critiques or suggestions for improvement/simplification are very much welcome!

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
