### PR TITLE
Improve --scan-between

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # CHANGELOG
 
-## 1.3.0 - 2019-02-10
+## 1.3.3 - 2021-07-08
+* `--scan-between` Ignore merges.
+* `--scan-between` Include [to]..[from] commits in scan.
+* `--scan-between` Add more tests.
+
+## 1.3.2 - 2021-07-07
+* Add `--scan-between` subcommand to traverse and scan branch state between
+  a given commit range.
+
+## 1.3.1 - 2021-07-01
+* Support for Perl-like regular expressions with git-grep.
+
+## 1.3.0 - 2019-07-01
 
 * Empty provider output is now excluded
   (https://github.com/awslabs/git-secrets/issues/34)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 ## 1.3.1 - 2021-07-01
 * Support for Perl-like regular expressions with git-grep.
 
-## 1.3.0 - 2019-07-01
+## 1.3.0 - 2019-02-10
 
 * Empty provider output is now excluded
   (https://github.com/awslabs/git-secrets/issues/34)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * `--scan-between` Ignore merges.
 * `--scan-between` Include [to]..[from] commits in scan.
 * `--scan-between` Add more tests.
+* Fix bug causing patterns to be split by spaces rather than `\n` or `\r\n`.
 
 ## 1.3.2 - 2021-07-07
 * Add `--scan-between` subcommand to traverse and scan branch state between

--- a/README.rst
+++ b/README.rst
@@ -146,9 +146,11 @@ Each of these options must appear first on the command line.
     a colon, and then the line of text that matched.
 
 ``--scan-between``
-    Scans the repository between two given commits. The scan is based on
-    `first-parent <https://git-scm.com/docs/git-rev-list#Documentation/git-rev-list.txt---first-parent>`_ and `excludes merges <https://git-scm.com/docs/git-rev-list#Documentation/git-rev-list.txt---no-merges>`_. For example `hashA..hashB`. The scan is
-    inclusive of the each of the commit at both hashes. To scan the commit at
+    Scans the repository between two given commits.  For example `hashA..hashB`.
+    The scan is based on 
+    `first-parent <https://git-scm.com/docs/git-rev-list#Documentation/git-rev-list.txt---first-parent>`_
+    and `excludes merges <https://git-scm.com/docs/git-rev-list#Documentation/git-rev-list.txt---no-merges>`_. 
+    The scan is inclusive of the each of the commit at both hashes. To scan the commit at
     ``HEAD``, for example, use ``HEAD..HEAD``. To include the last two, use
     ``HEAD~1..HEAD``. All commits are resolved using ``git rev-parse``.
 

--- a/README.rst
+++ b/README.rst
@@ -146,10 +146,11 @@ Each of these options must appear first on the command line.
     a colon, and then the line of text that matched.
 
 ``--scan-between``
-    Scans the repository between two given commit hashes using `ancestory path <https://git-scm.com/docs/git-log#Documentation/git-log.txt---ancestry-path>`_.
-    For example `hashA..hashB`. The scan begins AFTER the first hash. So, to
-    include ``hashA``, you must specify ``hashA~1..hashB`` as the argument.
-    Similarly, to scan the last commit use: ``HEAD~1..HEAD``.
+    Scans the repository between two given commits. The scan is based on
+    `first-parent <https://git-scm.com/docs/git-rev-list#Documentation/git-rev-list.txt---first-parent>`_ and `excludes merges <https://git-scm.com/docs/git-rev-list#Documentation/git-rev-list.txt---no-merges>`_. For example `hashA..hashB`. The scan is
+    inclusive of the each of the commit at both hashes. To scan the commit at
+    ``HEAD``, for example, use ``HEAD..HEAD``. To include the last two, use
+    ``HEAD~1..HEAD``. All commits are resolved using ``git rev-parse``.
 
 ``--list``
     Lists the ``git-secrets`` configuration for the current repo or in the global

--- a/git-secrets
+++ b/git-secrets
@@ -144,8 +144,7 @@ scan_between() {
 
   local scan_from=$(echo "${scan_range}" | sed -nE "s/^(.*)\.\.(.*)$/\1/p")
   local scan_to=$(echo "${scan_range}" | sed -nE "s/^(.*)\.\.(.*)$/\2/p")
-  local -r commits_cmd="git log ${scan_range} --pretty=%h \
-    --reverse --first-parent --no-merges"
+  local -r commits_cmd=(git log "${scan_range}" --pretty=%h --reverse --first-parent --no-merges)
 
   # No commits means nothing to scan (OK)
   to_and_from_identical=$(check_if_commits_identical \
@@ -154,7 +153,7 @@ scan_between() {
   if [[ ${to_and_from_identical} == true ]]; then
     commits="${scan_from}"
   else
-    IFS=$'\n' read -r -d '' -a commits < <( ${commits_cmd} && printf '\0' )
+    IFS=$'\n' read -r -d '' -a commits < <( "${commits_cmd[@]}" && printf '\0' )
     commits=($(git rev-parse --short "${scan_from}") "${commits[@]}")
   fi
   [ -z "${commits[*]}" ] && return 0

--- a/git-secrets
+++ b/git-secrets
@@ -156,7 +156,6 @@ scan_between() {
   else
     IFS=$'\n' read -r -d '' -a commits < <( ${commits_cmd} && printf '\0' )
     commits=($(git rev-parse --short "${scan_from}") "${commits[@]}")
-    unset IFS
   fi
   [ -z "${commits[*]}" ] && return 0
 

--- a/git-secrets
+++ b/git-secrets
@@ -115,7 +115,7 @@ check_if_commits_identical() {
   local -r second="${2}"
   local first_hash=$(git rev-parse "${first}")
   local second_hash=$(git rev-parse "${second}")
-  if [[ ${first_hash} == ${second_hash} ]]; then
+  if [[ ${first_hash} == "${second_hash}" ]]; then
     echo true
   else
     echo false
@@ -125,7 +125,7 @@ check_if_commits_identical() {
 check_if_first_commit() {
   local -r first_commit=$(git rev-list --max-parents=0 HEAD)
   local comparison=${1}
-  echo $(check_if_commits_identical "${first_commit}" "${comparison}")
+  check_if_commits_identical "${first_commit}" "${comparison}"
 }
 
 # Takes an argument like commitHashA..commitHashB
@@ -155,12 +155,10 @@ scan_between() {
     commits="${scan_from}"
   else
     IFS=$'\n' read -r -d '' -a commits < <( ${commits_cmd} && printf '\0' )
-    commits=($(git rev-parse --short "${scan_from}") ${commits[@]})
+    commits=($(git rev-parse --short "${scan_from}") "${commits[@]}")
     unset IFS
   fi
-  [ -z "${commits}" ] && return 0
-
-  local -r current_branch=$(git branch --show-current)
+  [ -z "${commits[*]}" ] && return 0
 
   declare found
   for commit_hash in "${commits[@]}"; do

--- a/git-secrets
+++ b/git-secrets
@@ -110,15 +110,22 @@ scan_history() {
   process_output $? "${output}"
 }
 
-check_if_first_commit() {
-  local -r first_commit=$(git rev-list --max-parents=0 HEAD)
-  local scan_to=${1}
-  [[ ${scan_to} == "HEAD" ]] && scan_to=$(git rev-parse HEAD)
-  if [[ ${scan_to} == ${first_commit} ]]; then
+check_if_commits_identical() {
+  local -r first="${1}"
+  local -r second="${2}"
+  local first_hash=$(git rev-parse "${first}")
+  local second_hash=$(git rev-parse "${second}")
+  if [[ ${first_hash} == ${second_hash} ]]; then
     echo true
   else
     echo false
   fi
+}
+
+check_if_first_commit() {
+  local -r first_commit=$(git rev-list --max-parents=0 HEAD)
+  local comparison=${1}
+  echo $(check_if_commits_identical "${first_commit}" "${comparison}")
 }
 
 # Takes an argument like commitHashA..commitHashB
@@ -135,25 +142,29 @@ scan_between() {
   local combined_patterns=$(load_combined_patterns)
   [ -z "${combined_patterns}" ] && return 0
 
+  local scan_from=$(echo "${scan_range}" | sed -nE "s/^(.*)\.\.(.*)$/\1/p")
   local scan_to=$(echo "${scan_range}" | sed -nE "s/^(.*)\.\.(.*)$/\2/p")
-  is_first_commit=$(check_if_first_commit "${scan_to}")
-  if [[ ${is_first_commit} == true ]]; then
-    scan_range="4b825dc642cb6eb9a060e54bf8d69288fbee4904..HEAD"
-    # First commit is bottom commit
-    local -r commits_cmd="git log ${scan_range} --pretty=%h --reverse"
-  else
-    local -r commits_cmd="git log ${scan_range} --pretty=%h --reverse --ancestry-path"
-  fi
+  local -r commits_cmd="git log ${scan_range} --pretty=%h \
+    --reverse --first-parent --no-merges"
 
   # No commits means nothing to scan (OK)
-  IFS=$'\n' read -r -d '' -a commits < <( ${commits_cmd} && printf '\0' )
+  to_and_from_identical=$(check_if_commits_identical \
+    "${scan_to}" "${scan_from}")
+
+  if [[ ${to_and_from_identical} == true ]]; then
+    commits="${scan_from}"
+  else
+    IFS=$'\n' read -r -d '' -a commits < <( ${commits_cmd} && printf '\0' )
+    commits=($(git rev-parse --short "${scan_from}") ${commits[@]})
+    unset IFS
+  fi
   [ -z "${commits}" ] && return 0
-  unset IFS
 
   local -r current_branch=$(git branch --show-current)
 
   declare found
   for commit_hash in "${commits[@]}"; do
+    local is_first_commit=$(check_if_first_commit "${commit_hash}")
     if [[ ${is_first_commit} == true ]]; then
       local files_changed=$(git diff HEAD --name-only)
     else

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -3,7 +3,7 @@ export TEST_REPO="$BATS_TMPDIR/test-repo"
 export TEMP_HOME="$BATS_TMPDIR/home"
 export TEMPLATE_DIR="${BATS_TMPDIR}/template"
 INITIAL_PATH="${PATH}"
-INITIAL_HOME=${HOME}
+INITIAL_HOME="${HOME}"
 
 setup() {
   setup_repo


### PR DESCRIPTION
## What?
* `--scan-between` Ignore merges.                                                          
* `--scan-between` Include `[to]..[from]` rather than `[to+1]..[from]` commits in scan so that behavior matches up to `git rev-parse`.          
* `--scan-between` Add more tests.
* Update docs/changelog

## Why?
The implementation of `--scan-between` needed improvement to be usable in reality.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
