### PR TITLE
Do not rely on IFS from env when loading combined patterns

### DIFF
--- a/git-secrets
+++ b/git-secrets
@@ -76,9 +76,9 @@ load_allowed() {
 load_combined_patterns() {
   local patterns=$(load_patterns)
   local combined_patterns=''
-  for pattern in $patterns; do
+  while IFS=$'\n' read -r pattern; do
     combined_patterns=${combined_patterns}${pattern}"|"
-  done
+  done <<< "${patterns}"
   combined_patterns=${combined_patterns%?}
   echo $combined_patterns
 }


### PR DESCRIPTION
## What?
- load patterns delimited by `'\n`' rather than default IFS `' \t\n'` (space, tab, newline)
- use `while` instead of `for` to avoid modifying/relying on the global value of `IFS` (general best practice)
- PR also opened on the [awslabs/git-secrets](https://github.com/awslabs/git-secrets/pull/197) side

## Why?
- `combined_patterns()` concatenates patterns with `|` for use in a single grep command
- using the default value of IFS means patterns containing a space character delimited by space, rather than newline
- this causes unexpected behavior (false matches from words split by space)

## Expected
For example, consider the following list of patterns:
```bash
^my-regex$
^my regex with spaces$
```

`load_combined_patterns()` should transform them into: `^my-regex$|^my regex with spaces$`

## Actual
The above example ends up as `^my-regex$|^my|regex|with|spaces$`.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._