### PR TITLE
Fix possible trailing newline/carriage return(s) for process_output()

### DIFF
--- a/git-secrets
+++ b/git-secrets
@@ -206,7 +206,7 @@ process_output() {
       [ -z "${allowed}" ] && echo "${output}" >&2 && return 1
       # Determine with a negative grep if the found matches are allowed
       #
-      # Clean the output in case of a trailing \r, \n, (or combination of those)
+      # Clean the output in case of a trailing \r, \n (or combination of those)
       matches=$(echo "${output}" | GREP_OPTIONS= LC_ALL=C grep -Ev "${allowed}")
       cleaned_matches=$(echo "${matches}" | awk 'NR>1{print PREV} {PREV=$0} END{printf("%s",$0)}' | tr -d $'\r')
       [[ -n ${cleaned_matches} ]] && echo "${cleaned_matches}" >&2 && return 1

--- a/git-secrets
+++ b/git-secrets
@@ -205,8 +205,12 @@ process_output() {
     0)
       [ -z "${allowed}" ] && echo "${output}" >&2 && return 1
       # Determine with a negative grep if the found matches are allowed
-      echo "${output}" | GREP_OPTIONS= LC_ALL=C grep -Ev "${allowed}" >&2 \
-        && return 1 || return 0
+      #
+      # Clean the output in case of a trailing \r, \n, (or combination of those)
+      matches=$(echo "${output}" | GREP_OPTIONS= LC_ALL=C grep -Ev "${allowed}")
+      cleaned_matches=$(echo "${matches}" | awk 'NR>1{print PREV} {PREV=$0} END{printf("%s",$0)}' | tr -d $'\r')
+      [[ -n ${cleaned_matches} ]] && echo "${cleaned_matches}" >&2 && return 1
+      return 0
       ;;
     1) return 0 ;;
     *) exit $status


### PR DESCRIPTION
## What?
Fix possibility of trailing `\n`, `\r` or combination of these.

## Why?
Trailing `\n` or `\r`(s) as a result of the negative grep are possible. This causes a false detection since the script will return in error (i.e. matches detected). If there's no actual matches we want exit successfully.

This bug is known to occur when using `.gitallowed` and is currently a blocker for one known PR.